### PR TITLE
Replace int with int64 type to generate number

### DIFF
--- a/driver/randomdevice.go
+++ b/driver/randomdevice.go
@@ -19,15 +19,15 @@ const (
 )
 
 type randomDevice struct {
-	minInt8  int
-	maxInt8  int
-	minInt16 int
-	maxInt16 int
-	minInt32 int
-	maxInt32 int
+	minInt8  int64
+	maxInt8  int64
+	minInt16 int64
+	maxInt16 int64
+	minInt32 int64
+	maxInt32 int64
 }
 
-func (d *randomDevice) value(valueType string) (int, error) {
+func (d *randomDevice) value(valueType string) (int64, error) {
 	switch valueType {
 	case "Int8":
 		if d.maxInt8 <= d.minInt8 {
@@ -63,7 +63,7 @@ func newRandomDevice() *randomDevice {
 	}
 }
 
-func random(min int, max int) int {
+func random(min int64, max int64) int64 {
 	rand.Seed(time.Now().UnixNano())
-	return rand.Intn(max-min) + min
+	return rand.Int63n(max-min) + min
 }

--- a/driver/randomdriver.go
+++ b/driver/randomdriver.go
@@ -85,7 +85,7 @@ func (d *RandomDriver) HandleWriteCommands(addr *models.Addressable, reqs []dsMo
 				return fmt.Errorf("RandomDriver.HandleWriteCommands: minimum value %d of %T must be int between %d ~ %d", v, v, defMinInt8, defMaxInt8)
 			}
 
-			rd.minInt8 = int(v)
+			rd.minInt8 = int64(v)
 		case "Max_Int8":
 			v, err := param.Int8Value()
 			if err != nil {
@@ -95,7 +95,7 @@ func (d *RandomDriver) HandleWriteCommands(addr *models.Addressable, reqs []dsMo
 				return fmt.Errorf("RandomDriver.HandleWriteCommands: maximum value %d of %T must be int between %d ~ %d", v, v, defMinInt8, defMaxInt8)
 			}
 
-			rd.maxInt8 = int(v)
+			rd.maxInt8 = int64(v)
 		case "Min_Int16":
 			v, err := param.Int16Value()
 			if err != nil {
@@ -105,7 +105,7 @@ func (d *RandomDriver) HandleWriteCommands(addr *models.Addressable, reqs []dsMo
 				return fmt.Errorf("RandomDriver.HandleWriteCommands: minimum value %d of %T must be int between %d ~ %d", v, v, defMinInt16, defMaxInt16)
 			}
 
-			rd.minInt16 = int(v)
+			rd.minInt16 = int64(v)
 		case "Max_Int16":
 			v, err := param.Int16Value()
 			if err != nil {
@@ -115,7 +115,7 @@ func (d *RandomDriver) HandleWriteCommands(addr *models.Addressable, reqs []dsMo
 				return fmt.Errorf("RandomDriver.HandleWriteCommands: maximum value %d of %T must be int between %d ~ %d", v, v, defMinInt16, defMaxInt16)
 			}
 
-			rd.maxInt16 = int(v)
+			rd.maxInt16 = int64(v)
 		case "Min_Int32":
 			v, err := param.Int32Value()
 			if err != nil {
@@ -125,7 +125,7 @@ func (d *RandomDriver) HandleWriteCommands(addr *models.Addressable, reqs []dsMo
 				return fmt.Errorf("RandomDriver.HandleWriteCommands: minimum value %d of %T must be int between %d ~ %d", v, v, defMinInt32, defMaxInt32)
 			}
 
-			rd.minInt32 = int(v)
+			rd.minInt32 = int64(v)
 		case "Max_Int32":
 			v, err := param.Int32Value()
 			if err != nil {
@@ -135,7 +135,7 @@ func (d *RandomDriver) HandleWriteCommands(addr *models.Addressable, reqs []dsMo
 				return fmt.Errorf("RandomDriver.HandleWriteCommands: maximum value %d of %T must be int between %d ~ %d", v, v, defMinInt32, defMaxInt32)
 			}
 
-			rd.maxInt32 = int(v)
+			rd.maxInt32 = int64(v)
 		default:
 			return fmt.Errorf("RandomDriver.HandleWriteCommands: there is no matched device resource for %s", param.String())
 		}


### PR DESCRIPTION
The range of int data is different on 32 and 64 bit system
On 32 bit system, the value might be out of range
Using int64 to generate random number could resolve this issue
fix #24

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>