### PR TITLE
Fix the typo in the sample device profile

### DIFF
--- a/cmd/res/device.random.yaml
+++ b/cmd/res/device.random.yaml
@@ -141,7 +141,7 @@ commands:
       expectedValues: []
   put:
     path: "/api/v1/device/{deviceId}/GenerateRandomValue_Int16"
-    parameterNames: ["Min_Int8","Max_Int8"]
+    parameterNames: ["Min_Int16","Max_Int16"]
     responses:
     -
       code: "200"


### PR DESCRIPTION
For the put command of GenerateRandomValue_Int16,
the parameter names should be Min_Int16 and Max_Int16
fix #26

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>