### PR TITLE
Update docker entrypoint params to run with consul

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ EXPOSE $APP_PORT
 
 COPY --from=builder /go/src/github.com/edgexfoundry/device-random/cmd /
 
-ENTRYPOINT ["/device-random","--profile=docker","--confdir=/res"]
+ENTRYPOINT ["/device-random","--profile=docker","--confdir=/res","--registry=consul://edgex-core-consul:8500"]


### PR DESCRIPTION
Add flag "--registry=consul://edgex-core-consul:8500" to the Dockerfile
ENTRYPOINT

fix: #80 

Signed-off-by: Felix Ting <felix@iotechsys.com>