### PR TITLE
ci: update local docker image names in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,6 @@ docker: $(DOCKERS)
 docker_device_random_go:
 	docker build \
 		--label "git_sha=$(GIT_SHA)" \
-		-t edgexfoundry/docker-device-random-go:$(GIT_SHA) \
-		-t edgexfoundry/docker-device-random-go:$(VERSION)-dev \
+		-t edgexfoundry/device-random:$(GIT_SHA) \
+		-t edgexfoundry/device-random:$(VERSION)-dev \
 		.


### PR DESCRIPTION
As part of the Ireland release it was decided to remove the docker- in the image prefix and -go in the image suffix.